### PR TITLE
Add documentation about action checkout for usage of bridge in GitHub

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -20,7 +20,7 @@ jobs:
         smalltalk: [ Pharo64-7.0, Pharo64-8.0, Pharo64-9.0, Pharo64-10 ]
     name: ${{ matrix.smalltalk }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
           with:
             fetch-depth: '0'
       - uses: hpi-swa/setup-smalltalkCI@v1

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -21,6 +21,8 @@ jobs:
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-version: ${{ matrix.smalltalk }}

--- a/resources/documentation/UserGuide.md
+++ b/resources/documentation/UserGuide.md
@@ -165,13 +165,13 @@ Where `src` will need to be changed to correspond to your code subdirectory.
 
 ### Use GitHub actions
 
-When using GitHub actions, it is necessary to configure the `actions/checkout@v2` to fetch the all commits history.
+When using GitHub actions, it is necessary to configure the `actions/checkout@v3` to fetch the all commits history.
 
 Using the action looks like this:
 
 ```yml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
     with:
       fetch-depth: '0'
 ```

--- a/resources/documentation/UserGuide.md
+++ b/resources/documentation/UserGuide.md
@@ -162,3 +162,16 @@ The script will look like this:
 ```
 
 Where `src` will need to be changed to correspond to your code subdirectory.
+
+### Use GitHub actions
+
+When using GitHub actions, it is necessary to configure the `actions/checkout@v2` to fetch the all commits history.
+
+Using the action looks like this:
+
+```yml
+steps:
+  - uses: actions/checkout@v2
+    with:
+      fetch-depth: '0'
+```


### PR DESCRIPTION
In my experience, when using gitbridge with GitHub actions, you have to download the all commit history because it is used by Iceber.

Following the documentation of [actions/checkout](https://github.com/actions/checkout), we have to set the "fetch-depth" attribute in order to get the history of commits for iceberg